### PR TITLE
Updates expression grammar to link anyExpression to relationalExpression

### DIFF
--- a/dsl-antlr/src/main/antlr4/org/fixtrading/orchestra/dsl/antlr/Score.g4
+++ b/dsl-antlr/src/main/antlr4/org/fixtrading/orchestra/dsl/antlr/Score.g4
@@ -33,6 +33,7 @@ anyExpression
     : assignment
     | conditionalOrExpression
     | conditionalAndExpression
+	| relationalExpression
     ;
 
 assignment
@@ -76,7 +77,7 @@ factor
    ;
 
 value // immutable
-    : 'this' '.' qualifiedId
+    : THIS '.' qualifiedId
     ;
 
 variable // mutable

--- a/dsl-antlr/src/test/java/org/fixtrading/orchestra/dsl/antlr/DslTest.java
+++ b/dsl-antlr/src/test/java/org/fixtrading/orchestra/dsl/antlr/DslTest.java
@@ -18,6 +18,8 @@ public class DslTest {
 
   @BeforeClass
   public static void init() {
+    fieldConditions.add("this.OrdType");
+    fieldConditions.add("\"Stop\"");
     fieldConditions.add("this.OrdType == \"Stop\"");
     fieldConditions.add("this.OrdType in {\"Stop\", \"StopLimit\"}");
   }


### PR DESCRIPTION
The anyExpression rule was missing a link to the relationalExpression rule.   Adding that in fixes the tests.