### PR TITLE
V1.1schema

### DIFF
--- a/dsl-antlr/pom.xml
+++ b/dsl-antlr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>io.fixprotocol.orchestra</groupId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>dsl-antlr</artifactId>

--- a/interfaces-util/pom.xml
+++ b/interfaces-util/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.fixprotocol.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>interfaces-util</artifactId>
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/interfaces/pom.xml
+++ b/interfaces/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.fixprotocol.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>interfaces</artifactId>
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/message-model/pom.xml
+++ b/message-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.fixprotocol.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>message-model</artifactId>
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/orchestra-common/pom.xml
+++ b/orchestra-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.fixprotocol.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>orchestra-common</artifactId>
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/orchestra2doc/pom.xml
+++ b/orchestra2doc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.fixprotocol.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>orchestra2doc</artifactId>
 	<description>Generates humanly readable documentation</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.fixprotocol.orchestra</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.7.2-SNAPSHOT</version>
+	<version>1.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Parent project for FIX Orchestra. Build Java 8 by default, multi-release jar on demand.</description>

--- a/repository-util/pom.xml
+++ b/repository-util/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.fixprotocol.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>repository-util</artifactId>
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.fixprotocol.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>repository</artifactId>
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/repository/src/main/resources/xsd/repository.xsd
+++ b/repository/src/main/resources/xsd/repository.xsd
@@ -112,6 +112,7 @@
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="name" type="fixr:Name_t" use="required"/>
+			<xs:attribute name="scenario" type="fixr:Scenario_t" default="base"/>
 			<xs:attribute name="baseType" type="fixr:Name_t"/>
 			<xs:attributeGroup ref="fixr:entityAttribGrp"/>
 		</xs:complexType>
@@ -234,10 +235,12 @@
 		<xs:key name="typeKey">
 			<xs:selector xpath="fixr:codeSets/fixr:codeSet|fixr:datatypes/fixr:datatype"/>
 			<xs:field xpath="@name"/>
+			<xs:field xpath="@scenario"/>
 		</xs:key>
 		<xs:keyref name="typeKeyref" refer="fixr:typeKey">
 			<xs:selector xpath="fixr:fields/fixr:field"/>
 			<xs:field xpath="@type"/>
+			<xs:field xpath="@scenario"/>
 		</xs:keyref>
 	</xs:element>
 	<xs:element name="sections">

--- a/repository/src/main/resources/xsd/repository.xsd
+++ b/repository/src/main/resources/xsd/repository.xsd
@@ -22,6 +22,7 @@
 					<xs:element name="actor" type="fixr:actorType"/>
 					<xs:element name="flow" type="fixr:flowType"/>
 				</xs:choice>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute ref="xml:base"/>
 		</xs:complexType>
@@ -46,6 +47,7 @@
 						<xs:documentation>A business process category, a subcategory of a businessArea</xs:documentation>
 					</xs:annotation>
 				</xs:element>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
 			<xs:attribute ref="xml:base"/>
@@ -60,6 +62,7 @@
 						<xs:field xpath="@name"/>
 					</xs:key>
 				</xs:element>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute ref="xml:base"/>
 		</xs:complexType>
@@ -78,6 +81,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="component" type="fixr:componentType" maxOccurs="unbounded"/>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
 			<xs:attribute ref="xml:base"/>
@@ -97,6 +101,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="concept" type="fixr:conceptType" maxOccurs="unbounded"/>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute ref="xml:base"/>
 		</xs:complexType>
@@ -121,6 +126,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element ref="fixr:datatype" maxOccurs="unbounded"/>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
 			<xs:attribute ref="xml:base"/>
@@ -130,6 +136,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="field" type="fixr:fieldType" maxOccurs="unbounded"/>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="latestEP" type="fixr:EP_t"/>
 			<xs:attribute ref="xml:base"/>
@@ -149,6 +156,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="group" type="fixr:groupType" maxOccurs="unbounded"/>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
 			<xs:attribute ref="xml:base"/>
@@ -168,6 +176,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="message" type="fixr:messageType" maxOccurs="unbounded"/>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
 			<xs:attribute ref="xml:base"/>
@@ -251,6 +260,7 @@
 						<xs:documentation>A large-grained business process category</xs:documentation>
 					</xs:annotation>
 				</xs:element>
+				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
 			<xs:attribute ref="xml:base"/>

--- a/repository/src/main/resources/xsd/repository.xsd
+++ b/repository/src/main/resources/xsd/repository.xsd
@@ -18,7 +18,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:choice maxOccurs="unbounded">
+				<xs:choice minOccurs="0" maxOccurs="unbounded">
 					<xs:element name="actor" type="fixr:actorType"/>
 					<xs:element name="flow" type="fixr:flowType"/>
 				</xs:choice>
@@ -42,7 +42,7 @@
 	<xs:element name="categories">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="category" type="fixr:categoryType" maxOccurs="unbounded">
+				<xs:element name="category" type="fixr:categoryType" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>A business process category, a subcategory of a businessArea</xs:documentation>
 					</xs:annotation>
@@ -56,7 +56,7 @@
 	<xs:element name="codeSets">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="codeSet" type="fixr:codeSetType" maxOccurs="unbounded">
+				<xs:element name="codeSet" type="fixr:codeSetType" minOccurs="0" maxOccurs="unbounded">
 					<xs:key name="codeKey">
 						<xs:selector xpath="fixr:code"/>
 						<xs:field xpath="@name"/>
@@ -80,7 +80,7 @@
 	<xs:element name="components">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="component" type="fixr:componentType" maxOccurs="unbounded"/>
+				<xs:element name="component" type="fixr:componentType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
@@ -100,7 +100,7 @@
 	<xs:element name="concepts">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="concept" type="fixr:conceptType" maxOccurs="unbounded"/>
+				<xs:element name="concept" type="fixr:conceptType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute ref="xml:base"/>
@@ -125,7 +125,7 @@
 	<xs:element name="datatypes">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element ref="fixr:datatype" maxOccurs="unbounded"/>
+				<xs:element ref="fixr:datatype" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
@@ -135,7 +135,7 @@
 	<xs:element name="fields">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="field" type="fixr:fieldType" maxOccurs="unbounded"/>
+				<xs:element name="field" type="fixr:fieldType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="latestEP" type="fixr:EP_t"/>
@@ -155,7 +155,7 @@
 	<xs:element name="groups">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="group" type="fixr:groupType" maxOccurs="unbounded"/>
+				<xs:element name="group" type="fixr:groupType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
@@ -175,7 +175,7 @@
 	<xs:element name="messages">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="message" type="fixr:messageType" maxOccurs="unbounded"/>
+				<xs:element name="message" type="fixr:messageType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attributeGroup ref="fixr:containerAttribGrp"/>
@@ -255,7 +255,7 @@
 	<xs:element name="sections">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="section" type="fixr:sectionType" maxOccurs="unbounded">
+				<xs:element name="section" type="fixr:sectionType" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>A large-grained business process category</xs:documentation>
 					</xs:annotation>

--- a/repository/src/main/resources/xsd/repository.xsd
+++ b/repository/src/main/resources/xsd/repository.xsd
@@ -117,7 +117,7 @@
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="name" type="fixr:Name_t" use="required"/>
-			<xs:attribute name="scenario" type="fixr:Scenario_t" default="base"/>
+			<xs:attribute name="scenario" type="fixr:Name_t" default="base"/>
 			<xs:attribute name="baseType" type="fixr:Name_t"/>
 			<xs:attributeGroup ref="fixr:entityAttribGrp"/>
 		</xs:complexType>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -166,7 +166,7 @@
 		</xs:sequence>
 		<xs:attributeGroup ref="fixr:oidGrp"/>
 		<xs:attribute name="value" type="xs:string" use="required"/>
-		<xs:attribute name="sort" type="xs:string"/>
+		<xs:attribute name="sort" type="xs:nonNegativeInteger"/>
 		<xs:attribute name="group" type="xs:string"/>
 		<xs:attributeGroup ref="fixr:entityAttribGrp"/>
 	</xs:complexType>
@@ -863,9 +863,6 @@
 		<xs:attribute name="FIXMLFileName" type="fixr:Name_t"/>
 		<xs:attributeGroup ref="fixr:entityAttribGrp"/>
 	</xs:complexType>
-	<xs:simpleType name="Sort_t">
-		<xs:restriction base="xs:nonNegativeInteger"/>
-	</xs:simpleType>
 	<xs:complexType name="stateMachineType">
 		<xs:sequence>
 			<xs:element name="initial" type="fixr:stateType">

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -725,10 +725,12 @@
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="Name_t">
-		<xs:restriction base="xs:string">
+		<xs:annotation>
+			<xs:documentation>Names are from 1-64 characters. The XML processor will remove line feeds, carriage returns, tabs, leading and trailing spaces, and multiple spaces. Internal spaces are allowed by the schema but may be restricted by an external style.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
 			<xs:minLength value="1"/>
-			<xs:maxLength value="255"/>
-			<xs:pattern value="([A-Z]|[a-z])([0-9]|[A-Z]|[a-z]|_)*"/>
+			<xs:maxLength value="64"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:attributeGroup name="oidGrp">

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -674,7 +674,6 @@
 		<xs:sequence>
 			<xs:element name="identifiers" type="fixr:identifiersType" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute name="name" type="fixr:Name_t" use="required"/>
 		<xs:attribute name="msgType" type="fixr:MsgType_t"/>
 		<xs:attributeGroup ref="fixr:refidGrp"/>
 		<xs:attribute name="implMinOccurs" type="xs:positiveInteger" default="1"/>
@@ -816,6 +815,7 @@
 				<xs:documentation>Numeric identifier generally must be unique within a file for an element type, e.g. unique field tag</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute name="name" type="fixr:Name_t" use="required"/>
 		<xs:attribute name="scenario" type="fixr:Name_t" default="base">
 			<xs:annotation>
 				<xs:documentation>The use case of an element, distinguished by workflow, asset class, etc.</xs:documentation>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -1029,13 +1029,12 @@
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
 	<xs:simpleType name="Version_t">
-		<xs:restriction base="xs:string">
+		<xs:restriction base="xs:token">
 			<xs:annotation>
-				<xs:documentation>Enumerated FIX versions or major.minor or date as
-					yyyymmdd of any protocol
+				<xs:documentation>Uniquely identifies a revision. Many formats are impossible, including but not limited to protocol version label, semantic versioning, date, or simple integer.
+				The format may be restricted by an external style.
 				</xs:documentation>
 			</xs:annotation>
-			<xs:pattern value="(FIX.2.7)|(FIX.3.0)|(FIX\.4\.[0-4])|((FIX.Latest|(FIX\.5\.0(SP\d{1,2})?))(_EP((9[8-9])|([1-9][0-9][0-9])))?)|(FIXT.1.1)|([0-9]+)\.([0-9]+)|(\d{8})"/>
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -8,9 +8,6 @@
 			International Public License
 		</xs:documentation>
 	</xs:annotation>
-	<xs:simpleType name="Abbreviation_t">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
 	<xs:complexType name="actionType">
 		<xs:sequence>
 			<xs:choice id="parameters" minOccurs="0" maxOccurs="unbounded">
@@ -666,7 +663,7 @@
 	<xs:attributeGroup name="messageAttribGrp">
 		<xs:attribute name="msgType" type="fixr:MsgType_t"/>
 		<xs:attribute name="category" type="fixr:Name_t"/>
-		<xs:attribute name="abbrName" type="fixr:Abbreviation_t"/>
+		<xs:attribute name="abbrName" type="fixr:Name_t"/>
 		<xs:attribute name="rendering" type="xs:string">
 			<xs:annotation>
 				<xs:documentation>A hint to processes about how to interpret the element. Not validated.</xs:documentation>
@@ -751,8 +748,8 @@
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="name" type="fixr:Name_t" use="required"/>
-		<xs:attribute name="abbrName" type="fixr:Abbreviation_t"/>
-		<xs:attribute name="scenario" type="fixr:Scenario_t" default="base">
+		<xs:attribute name="abbrName" type="fixr:Name_t"/>
+		<xs:attribute name="scenario" type="fixr:Name_t" default="base">
 			<xs:annotation>
 				<xs:documentation>The use case of an element, distinguished by workflow, asset class, etc.</xs:documentation>
 			</xs:annotation>
@@ -819,7 +816,7 @@
 				<xs:documentation>Numeric identifier generally must be unique within a file for an element type, e.g. unique field tag</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="scenario" type="fixr:Scenario_t" default="base">
+		<xs:attribute name="scenario" type="fixr:Name_t" default="base">
 			<xs:annotation>
 				<xs:documentation>The use case of an element, distinguished by workflow, asset class, etc.</xs:documentation>
 			</xs:annotation>
@@ -857,13 +854,6 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<xs:simpleType name="Scenario_t">
-		<xs:restriction base="xs:string">
-			<xs:minLength value="1"/>
-			<xs:maxLength value="255"/>
-			<xs:pattern value="([A-Z]|[a-z])([0-9]|[A-Z]|[a-z]|_|-)*"/>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:complexType name="sectionType">
 		<xs:sequence>
 			<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -815,7 +815,11 @@
 				<xs:documentation>Numeric identifier generally must be unique within a file for an element type, e.g. unique field tag</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="name" type="fixr:Name_t" use="required"/>
+		<xs:attribute name="name" type="fixr:Name_t">
+			<xs:annotation>
+				<xs:documentation>Name is optional for convenience, but it is not enforced by referential integrity. Only the name of the referred object is authoritative.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 		<xs:attribute name="scenario" type="fixr:Name_t" default="base">
 			<xs:annotation>
 				<xs:documentation>The use case of an element, distinguished by workflow, asset class, etc.</xs:documentation>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -165,8 +165,16 @@
 			<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="fixr:oidGrp"/>
-		<xs:attribute name="value" type="xs:string" use="required"/>
-		<xs:attribute name="sort" type="xs:nonNegativeInteger"/>
+		<xs:attribute name="value" type="xs:token" use="required">
+			<xs:annotation>
+				<xs:documentation>The XML processor will remove line feeds, carriage returns, tabs, leading and trailing spaces, and multiple spaces. However, single internal spaces are allowed. May be further restricted by an external style.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="sort" type="xs:nonNegativeInteger">
+			<xs:annotation>
+				<xs:documentation>Sort and group may be used to organize visualization of a code set.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 		<xs:attribute name="group" type="xs:string"/>
 		<xs:attributeGroup ref="fixr:entityAttribGrp"/>
 	</xs:complexType>
@@ -726,7 +734,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="Name_t">
 		<xs:annotation>
-			<xs:documentation>Names are from 1-64 characters. The XML processor will remove line feeds, carriage returns, tabs, leading and trailing spaces, and multiple spaces. Internal spaces are allowed by the schema but may be restricted by an external style.</xs:documentation>
+			<xs:documentation>Names are from 1-64 characters. The XML processor will remove line feeds, carriage returns, tabs, leading and trailing spaces, and multiple spaces. Single internal spaces are allowed by the schema but may be restricted by an external style.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:minLength value="1"/>

--- a/repository/src/test/resources/examples/v1-1.xml
+++ b/repository/src/test/resources/examples/v1-1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fixr:repository xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fixr="http://fixprotocol.io/2020/orchestra/repository" xmlns:functx="http://www.functx.com" xmlns:xs="http://www.w3.org/2001/XMLSchema" name="FIX.Latest" version="FIX.Latest_EP266" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://fixprotocol.io/2020/orchestra/repository file:///C:/Users/donme/GitHub/fix-orchestra/repository/src/main/resources/xsd/repository.xsd">
+	<fixr:metadata/>
+	<fixr:datatypes>
+		<fixr:datatype name="String">
+			<fixr:mappedDatatype standard="XML" builtin="true" base="xs:string"/>
+		</fixr:datatype>
+		<fixr:datatype name="String" scenario="normalized">
+			<fixr:mappedDatatype standard="XML" builtin="true" base="xs:token"/>
+		</fixr:datatype>
+		<fixr:datatype name="int" scenario="short">
+			<fixr:mappedDatatype standard="XML" builtin="true" base="xs:short"/>
+		</fixr:datatype>
+		<fixr:datatype name="int" scenario="long" >
+			<fixr:mappedDatatype standard="XML" builtin="true" base="xs:long"/>
+		</fixr:datatype>
+	</fixr:datatypes>
+	<fixr:codeSets>
+		<fixr:codeSet type="String" id="22" name="SecurityIDSourceCodeSet" scenario="Test1">
+			<fixr:code value="1" id="37785" name="CUSIP"/>
+		</fixr:codeSet>
+		<fixr:codeSet type="String" id="22" name="SecurityIDSourceCodeSet" scenario="Test2">
+			<fixr:code value="4" id="7965" name="ISIN"/>
+		</fixr:codeSet>
+	</fixr:codeSets>
+	<fixr:fields>
+		<fixr:field added="FIX.2.7" id="1" name="Account" type="String" abbrName="Acct">
+			<fixr:annotation>
+				<fixr:documentation purpose="SYNOPSIS">
+         Account mnemonic as agreed between buy and sell sides, e.g. broker and institution or investor/intermediary and fund manager.
+      </fixr:documentation>
+			</fixr:annotation>
+		</fixr:field>
+		<fixr:field added="FIX.2.7" id="22" name="SecurityIDSource" type="SecurityIDSourceCodeSet" updated="FIX.5.0SP2" updatedEP="161" abbrName="Src" unionDataType="Reserved100Plus" scenario="Test1">
+			<fixr:annotation>
+				<fixr:documentation purpose="SYNOPSIS">
+         Identifies class or source of the SecurityID(48) value.
+      </fixr:documentation>
+			</fixr:annotation>
+		</fixr:field>
+		<fixr:field added="FIX.2.7" id="22" name="SecurityIDSource" type="SecurityIDSourceCodeSet" updated="FIX.5.0SP2" updatedEP="161" abbrName="Src" unionDataType="Reserved100Plus" scenario="Test2">
+			<fixr:annotation>
+				<fixr:documentation purpose="SYNOPSIS">
+         Identifies class or source of the SecurityID(48) value.
+      </fixr:documentation>
+			</fixr:annotation>
+		</fixr:field>
+		<fixr:field type="String" id="48" name="SecurityID" abbrName="ID" added="FIX.2.7">
+			<fixr:annotation>
+				<fixr:documentation purpose="SYNOPSIS">
+         Security identifier value of SecurityIDSource (22) type (e.g. CUSIP, SEDOL, ISIN, etc). Requires SecurityIDSource.
+      </fixr:documentation>
+			</fixr:annotation>
+		</fixr:field>
+	</fixr:fields>
+	<fixr:components>
+		<fixr:component category="Common" added="FIX.4.3" id="1003" name="Instrument" abbrName="Instrmt">
+			<fixr:fieldRef id="48"/>
+			<fixr:fieldRef id="22"/>
+		</fixr:component>
+	</fixr:components>
+	<fixr:messages>
+		<fixr:message msgType="D" category="SingleGeneralOrderHandling" flow="OrderEntry" id="14" name="NewOrderSingle" abbrName="Order" added="FIX.2.7">
+			<fixr:structure>
+				<fixr:componentRef id="1003"/>
+			</fixr:structure>
+		</fixr:message>
+	</fixr:messages>
+</fixr:repository>

--- a/repository2010/pom.xml
+++ b/repository2010/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>io.fixprotocol.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.7.2-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>repository2010</artifactId>
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Several improvements to the v1.0 XML schema. So far, none of the proposed changes break back-compatibility for FIX Latest with the exception of a few names that exceed 64 characters (documented elsewhere).