### PR TITLE
[repository schema] Field type attribute does not distinguish between datatype and code set reference #170

### DIFF
--- a/repository/src/main/resources/xsd/repository.xsd
+++ b/repository/src/main/resources/xsd/repository.xsd
@@ -146,7 +146,12 @@
 	<xs:element name="fields">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="field" type="fixr:fieldType" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="field" type="fixr:fieldType" minOccurs="0" maxOccurs="unbounded">
+					<xs:key name="typeKey">
+						<xs:selector xpath="."/>
+						<xs:field xpath="@type|@codeSet"/>
+					</xs:key>
+				</xs:element>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="latestEP" type="fixr:EP_t"/>
@@ -250,14 +255,24 @@
 				</xs:annotation>
 			</xs:attribute>
 		</xs:complexType>
-		<xs:key name="typeKey">
-			<xs:selector xpath="fixr:codeSets/fixr:codeSet|fixr:datatypes/fixr:datatype"/>
+		<xs:key name="datatypeRefKey">
+			<xs:selector xpath="fixr:datatypes/fixr:datatype"/>
 			<xs:field xpath="@name"/>
 			<xs:field xpath="@scenarioId"/>
 		</xs:key>
-		<xs:keyref name="typeKeyref" refer="fixr:typeKey">
+		<xs:keyref name="typeKeyref" refer="fixr:datatypeRefKey">
 			<xs:selector xpath="fixr:fields/fixr:field"/>
 			<xs:field xpath="@type"/>
+			<xs:field xpath="@scenarioId"/>
+		</xs:keyref>
+		<xs:key name="codesetRefKey">
+			<xs:selector xpath="fixr:codeSets/fixr:codeSet"/>
+			<xs:field xpath="@name"/>
+			<xs:field xpath="@scenarioId"/>
+		</xs:key>
+		<xs:keyref name="codesetKeyref" refer="fixr:codesetRefKey">
+			<xs:selector xpath="fixr:fields/fixr:field"/>
+			<xs:field xpath="@codeSet"/>
 			<xs:field xpath="@scenarioId"/>
 		</xs:keyref>
 		<xs:key name="scenarioNameKey">

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -455,7 +455,7 @@
 				<xs:documentation>Name of this rule</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="type" type="xs:string">
+		<xs:attribute name="type" type="fixr:Name_t">
 			<xs:annotation>
 				<xs:documentation>Overrides the type of the referenced field.
 				</xs:documentation>
@@ -484,10 +484,15 @@
 		</xs:sequence>
 		<xs:attributeGroup ref="fixr:oidGrp"/>
 		<xs:attributeGroup ref="fixr:entityAttribGrp"/>
-		<xs:attribute name="type" type="xs:string" use="required">
+		<xs:attribute name="type" type="fixr:Name_t">
 			<xs:annotation>
-				<xs:documentation>Attribute type refers to either a datatype or a
-					codeSet, which carries an underlying datatype.
+				<xs:documentation>Attribute type refers to a datatype name
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="codeSet" type="fixr:Name_t">
+			<xs:annotation>
+				<xs:documentation>Attribute codeSet refers to a codeSet name
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>


### PR DESCRIPTION
Formerly, the `type` attribute of a field referenced either a datatype or a code set. (Semantically, a code set is a specialized datatype with a finite set of valid values.) This proposed schema change introduces a new field attribute `codeSet` while  `type` attribute only references a datatype. **The `type` and `codeSet` attributes are enforced by the schema to be mutually exclusive.**

Examples of valid field definitions, one with a code set and the other with a dataype:
```xml
<fixr:field codeSet="LocateReqdCodeSet" id="114" name="LocateReqd" abbrName="LocReqd" added="FIX.4.0"/>
<fixr:field type="Price" id="132" name="BidPx" abbrName="BidPx" added="FIX.4.0"/>
```

Invalid field definitions because they use the wrong attribute or an attribute is missing:
```xml
<fixr:field id="137" name="MiscFeeAmt" abbrName="Amt" added="FIX.4.0"/>
<fixr:field codeSet="Currency" id="138" name="MiscFeeCurr" abbrName="Curr" added="FIX.4.0"/>
<fixr:field type="MiscFeeTypeCodeSet" id="139" name="MiscFeeType" abbrName="Typ" added="FIX.4.0"/>
```

The example file does not pass validation due to schema changes. In fact, all Orchestra v1.0 compliant files will need to be converted; suggest adding Orchestra v1.0 to v1.1 conversion in orchestra-transposer utility and making it public. Also, existing code will need to change.