### PR TITLE
[repository schema] Explicit type scenarios for fields and type scenario overrides for fieldRefs

### DIFF
--- a/repository/src/main/resources/xsd/repository.xsd
+++ b/repository/src/main/resources/xsd/repository.xsd
@@ -150,6 +150,7 @@
 					<xs:key name="typeKey">
 						<xs:selector xpath="."/>
 						<xs:field xpath="@type|@codeSet"/>
+						<xs:field xpath="@typeScenarioId|@codeSetScenarioId"/>
 					</xs:key>
 				</xs:element>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
@@ -263,7 +264,7 @@
 		<xs:keyref name="typeKeyref" refer="fixr:datatypeRefKey">
 			<xs:selector xpath="fixr:fields/fixr:field"/>
 			<xs:field xpath="@type"/>
-			<xs:field xpath="@scenarioId"/>
+			<xs:field xpath="@typeScenarioId"/>
 		</xs:keyref>
 		<xs:key name="codesetRefKey">
 			<xs:selector xpath="fixr:codeSets/fixr:codeSet"/>
@@ -273,7 +274,7 @@
 		<xs:keyref name="codesetKeyref" refer="fixr:codesetRefKey">
 			<xs:selector xpath="fixr:fields/fixr:field"/>
 			<xs:field xpath="@codeSet"/>
-			<xs:field xpath="@scenarioId"/>
+			<xs:field xpath="@codeSetScenarioId"/>
 		</xs:keyref>
 		<xs:key name="scenarioNameKey">
 			<xs:selector xpath="fixr:scenarios/fixr:scenario"/>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -380,6 +380,46 @@
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
+	<xs:attributeGroup name="fieldTypeAttribGrp">
+		<xs:annotation>
+			<xs:documentation>Attributes of a field that specify its type (data type or code set)
+			</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="type" type="fixr:Name_t">
+			<xs:annotation>
+				<xs:documentation>Attribute type refers to a datatype name
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="typeScenario" type="fixr:Name_t" default="base">
+			<xs:annotation>
+				<xs:documentation>Scenario of the datatype
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="typeScenarioId" type="fixr:id_t" default="1">
+			<xs:annotation>
+				<xs:documentation>Unique identifier of the datatype scenario. Default is '1' for base scenario.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="codeSet" type="fixr:Name_t">
+			<xs:annotation>
+				<xs:documentation>Attribute codeSet refers to a codeSet name
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="codeSetScenario" type="fixr:Name_t" default="base">
+			<xs:annotation>
+				<xs:documentation>Scenario of the codeSet
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="codeSetScenarioId" type="fixr:id_t" default="1">
+			<xs:annotation>
+				<xs:documentation>Unique identifier of the codeSet scenario. Default is '1' for base scenario.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
 	<xs:complexType name="fieldRefType">
 		<xs:sequence>
 			<xs:element name="rule" type="fixr:fieldRuleType" minOccurs="0" maxOccurs="unbounded">
@@ -484,18 +524,7 @@
 		</xs:sequence>
 		<xs:attributeGroup ref="fixr:oidGrp"/>
 		<xs:attributeGroup ref="fixr:entityAttribGrp"/>
-		<xs:attribute name="type" type="fixr:Name_t">
-			<xs:annotation>
-				<xs:documentation>Attribute type refers to a datatype name
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="codeSet" type="fixr:Name_t">
-			<xs:annotation>
-				<xs:documentation>Attribute codeSet refers to a codeSet name
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
+		<xs:attributeGroup ref="fixr:fieldTypeAttribGrp"/>
 		<xs:attributeGroup ref="fixr:fieldAttribGrp"/>
 		<xs:attribute name="lengthId" type="fixr:id_t">
 			<xs:annotation>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -420,6 +420,34 @@
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
+	<xs:attributeGroup name="fieldRefTypeAttribGrp">
+		<xs:annotation>
+			<xs:documentation>Attributes of a field reference that allow overriding the scenario of the referenced field definition's type (data type or code set)
+			</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="typeScenario" type="fixr:Name_t">
+			<xs:annotation>
+				<xs:documentation>Scenario override for the datatype
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="typeScenarioId" type="fixr:id_t">
+			<xs:annotation>
+				<xs:documentation>Unique identifier of the datatype scenario override.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="codeSetScenario" type="fixr:Name_t">
+			<xs:annotation>
+				<xs:documentation>Scenario override for the codeSet
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="codeSetScenarioId" type="fixr:id_t">
+			<xs:annotation>
+				<xs:documentation>Unique identifier of the codeSet scenario override.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
 	<xs:complexType name="fieldRefType">
 		<xs:sequence>
 			<xs:element name="rule" type="fixr:fieldRuleType" minOccurs="0" maxOccurs="unbounded">
@@ -440,6 +468,7 @@
 			<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="fixr:refidGrp"/>
+		<xs:attributeGroup ref="fixr:fieldRefTypeAttribGrp"/>
 		<xs:attributeGroup ref="fixr:entityAttribGrp"/>
 		<xs:attribute name="lengthId" type="fixr:id_t">
 			<xs:annotation>


### PR DESCRIPTION
This PR is a follow-up to the discussion we had on #171 and in iMeetCentral.
It addresses the following 2 points:

1. The scenario for the data type or the code set should not be implicitly set to the same scenario of the field anymore. Instead, it should be specified in one of the new `typeScenarioId` and `codeSetScenarioId` attributes.
The reason for this change is that the current implicit link 1) is inconsistent with the rest of Orchestra where a missing scenario specification means "base" scenario, 2) limits the ability of having a field with scenario X point to data type or code set with scenario Y, and 3) causes confusion and mistakes for developers working with Orchestra.
2. Ability to override data type or code set scenario in field references.
We would like to allow overriding of `typeScenarioId` or `codeSetScenarioId` in field references, but still keep scenarios for field definitions and field references. This would allow 1) having just a single field definition and field references with `typeScenarioId`/`codeSetScenarioId` overrides (suggested by @kleihan as a way to simplify creating of new Orchestra-based specs), 2) having multiple field scenarios for reasons other than just each pointing to a different type/code set scenario, and 3) remain more backwards compatible with 1.0 (at least in the sense that field scenarios will not need to be removed).

I have some questions related to those changes.

- [Related to point 1] Can you please double-check that the key constraints defined in repository.xsd prohibit having a mix of `type+codeSetScenarioId` or `codeSet+typeScenarioId`?
- [Related to point 2] I've added only the changes to `repositoryTypes.xsd`. How can we define the following key constraints in `repository.xsd`?
  - For all `fieldRefs` (I assume the selector would be `.//fixr:fieldRef` on the `repository` level).
  - If a `typeScenarioId` or `codeSetScenarioId` is specified (how can we define this optionality?)
  - Make sure that it is a valid scenario for the referenced field definition's type or code set (how can we resolve the referenced field defintion's type/codeSet?)
- [Related to PR 171 and point 1] In `fieldRuleType`, there's an override for `type`. Shouldn't there be then also overrides for `codeSet`, `typeScenarioId`, `codeSetScenarioId`? I.e. in `fieldRuleType` shouldn't we replace `type` with the new `fieldTypeAttribGrp`?
- [General] Should we rather switch to using `typeId`/`codeSetId` (similar to how we do for scenarios and other elements that rely on `refidGrp`), or we'll stick to referencing the data type/code set by name only?

