### PR TITLE
Update upload artifact used for GItHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml
     - name: Upload package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Package
         path: "**/target/*.jar"


### PR DESCRIPTION
GitHub Actions deprecated upload artifact v2, needs to be updated to v4