### PR TITLE
[#228] Attribute scenarioRefID must be optional in general, only required when a reference is actually made

### DIFF
--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -876,9 +876,9 @@
 		<xs:annotation>
 			<xs:documentation>A reference to a scenario by its key identifiers. There are no defaults as scenario references are optional.</xs:documentation>
 		</xs:annotation>
-		<xs:attribute name="scenarioRefId" type="fixr:id_t" use="required">
+		<xs:attribute name="scenarioRefId" type="fixr:id_t">
 			<xs:annotation>
-				<xs:documentation>Unique identifier of a scenario.</xs:documentation>
+				<xs:documentation>Unique identifier of a scenario. The identifier is required when referencing another scenario.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="scenarioRef" type="fixr:Name_t">


### PR DESCRIPTION
Fixes #228