### PR TITLE
Remove scenario IDs

### DIFF
--- a/repository/src/main/resources/xsd/repository.xsd
+++ b/repository/src/main/resources/xsd/repository.xsd
@@ -59,9 +59,13 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="codeSet" type="fixr:codeSetType" minOccurs="0" maxOccurs="unbounded">
-					<xs:key name="codeKey">
+					<xs:key name="codeNameKey">
 						<xs:selector xpath="fixr:code"/>
 						<xs:field xpath="@name"/>
+					</xs:key>
+					<xs:key name="codeIdKey">
+						<xs:selector xpath="fixr:code"/>
+						<xs:field xpath="@id"/>
 					</xs:key>
 				</xs:element>
 				<xs:element ref="fixr:encodings" minOccurs="0"/>
@@ -77,7 +81,7 @@
 		<xs:key name="codeSetIdKey">
 			<xs:selector xpath="fixr:codeSet"/>
 			<xs:field xpath="@id"/>
-			<xs:field xpath="@scenarioId"/>
+			<xs:field xpath="@scenario"/>
 		</xs:key>
 	</xs:element>
 	<!-- Component definitions -->
@@ -98,7 +102,7 @@
 		<xs:key name="componentIdKey">
 			<xs:selector xpath="fixr:component"/>
 			<xs:field xpath="@id"/>
-			<xs:field xpath="@scenarioId"/>
+			<xs:field xpath="@scenario"/>
 		</xs:key>
 	</xs:element>
 	<!-- Concept definitions -->
@@ -127,7 +131,6 @@
 		<xs:key name="datatypeKey">
 			<xs:selector xpath="fixr:datatype"/>
 			<xs:field xpath="@name"/>
-			<xs:field xpath="@scenarioId"/>
 		</xs:key>
 	</xs:element>
 	<!-- Field definitions -->
@@ -135,10 +138,6 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="field" type="fixr:fieldType" minOccurs="0" maxOccurs="unbounded">
-					<xs:key name="typeKey">
-						<xs:selector xpath="."/>
-						<xs:field xpath="@type|@codeSet"/>
-					</xs:key>
 				</xs:element>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 			</xs:sequence>
@@ -152,7 +151,11 @@
 		<xs:key name="fieldIdKey">
 			<xs:selector xpath="fixr:field"/>
 			<xs:field xpath="@id"/>
-			<xs:field xpath="@scenarioId"/>
+			<xs:field xpath="@scenario"/>
+		</xs:key>
+		<xs:key name="fieldTypeOrCodeSetKey">
+			<xs:selector xpath="fixr:field"/>
+			<xs:field xpath="@type|@codeSet"/>
 		</xs:key>
 	</xs:element>
 	<!-- Group definitions -->
@@ -173,7 +176,7 @@
 		<xs:key name="groupIdKey">
 			<xs:selector xpath="fixr:group"/>
 			<xs:field xpath="@id"/>
-			<xs:field xpath="@scenarioId"/>
+			<xs:field xpath="@scenario"/>
 		</xs:key>
 	</xs:element>
 	<!-- Message definitions -->
@@ -200,7 +203,7 @@
 			</xs:annotation>
 			<xs:selector xpath="fixr:message"/>
 			<xs:field xpath="@id"/>
-			<xs:field xpath="@scenarioId"/>
+			<xs:field xpath="@scenario"/>
 		</xs:key>
 	</xs:element>
 	<!-- Main schema element with references to all supported elements -->
@@ -245,64 +248,21 @@
 				</xs:annotation>
 			</xs:attribute>
 		</xs:complexType>
-		<!-- Datatype definitions must have a unique combination of name and scenario ID -->
-		<xs:key name="datatypeRefKey">
-			<xs:selector xpath="fixr:datatypes/fixr:datatype"/>
-			<xs:field xpath="@name"/>
-			<xs:field xpath="@scenarioId"/>
-		</xs:key>
-		<!-- Type and scenario ID attributes in a field definition must reference a valid datatype name and scenario ID -->
-		<xs:keyref name="typeKeyref" refer="fixr:datatypeRefKey">
+		<!-- Type attribute of a code set definition must reference a valid datatype name -->
+		<xs:keyref name="codeSetTypeRef" refer="fixr:datatypeKey">
+			<xs:selector xpath="fixr:codeSets/fixr:codeSet"/>
+			<xs:field xpath="@type"/>
+		</xs:keyref>
+		<!-- Type attribute of a field definition must reference a valid datatype name -->
+		<xs:keyref name="fieldTypeRef" refer="fixr:datatypeKey">
 			<xs:selector xpath="fixr:fields/fixr:field"/>
 			<xs:field xpath="@type"/>
-			<xs:field xpath="@scenarioId"/>
 		</xs:keyref>
-		<!-- Code set definitions must have a unique combination of name and scenario ID -->
-		<xs:key name="codeSetRefKey">
-			<xs:selector xpath="fixr:codeSets/fixr:codeSet"/>
-			<xs:field xpath="@name"/>
-			<xs:field xpath="@scenarioId"/>
-		</xs:key>
-		<!-- Code set and scenario ID attributes in a field definition must reference a valid code set name and scenario ID -->
-		<xs:keyref name="codeSetKeyref" refer="fixr:codeSetRefKey">
+		<!-- Code set and scenario attributes in a field definition must reference a valid code set name and scenario -->
+		<xs:keyref name="fieldCodeSetRef" refer="fixr:codeSetNameKey">
 			<xs:selector xpath="fixr:fields/fixr:field"/>
 			<xs:field xpath="@codeSet"/>
-			<xs:field xpath="@scenarioId"/>
-		</xs:keyref>
-		<!-- Code set definitions must have a unique name across all scenario names -->
-		<xs:key name="scenarioNameKey">
-			<xs:selector xpath="fixr:scenarios/fixr:scenario"/>
-			<xs:field xpath="@name"/>
-		</xs:key>
-		<!-- Code set definitions must have a unique ID across all scenario IDs -->
-		<xs:key name="scenarioIdKey">
-			<xs:selector xpath="fixr:scenarios/fixr:scenario"/>
-			<xs:field xpath="@id"/>
-		</xs:key>
-		<!-- A scenario ID used in a code set definition must be a valid scenario defined in the list of scenarios -->
-		<xs:keyref name="codeSetScenarioKeyRef" refer="fixr:scenarioIdKey">
-			<xs:selector xpath="fixr:codeSet"/>
-			<xs:field xpath="@scenarioId"/>
-		</xs:keyref>
-		<!-- A scenario ID used in a datatype definition must be a valid scenario defined in the list of scenarios -->
-		<xs:keyref name="datatypeScenarioKeyRef" refer="fixr:scenarioIdKey">
-			<xs:selector xpath="fixr:datatype"/>
-			<xs:field xpath="@scenarioId"/>
-		</xs:keyref>
-		<!-- A scenario ID used in a component definition must be a valid scenario defined in the list of scenarios -->
-		<xs:keyref name="componentScenarioKeyRef" refer="fixr:scenarioIdKey">
-			<xs:selector xpath="fixr:component"/>
-			<xs:field xpath="@scenarioId"/>
-		</xs:keyref>
-		<!-- A scenario ID used in a group definition must be a valid scenario defined in the list of scenarios -->
-		<xs:keyref name="groupScenarioKeyRef" refer="fixr:scenarioIdKey">
-			<xs:selector xpath="fixr:group"/>
-			<xs:field xpath="@scenarioId"/>
-		</xs:keyref>
-		<!-- A scenario ID used in a message definition must be a valid scenario defined in the list of scenarios -->
-		<xs:keyref name="messageScenarioKeyRef" refer="fixr:scenarioIdKey">
-			<xs:selector xpath="fixr:message"/>
-			<xs:field xpath="@scenarioId"/>
+			<xs:field xpath="@scenario"/>
 		</xs:keyref>
 	</xs:element>
 	<!-- Scenario definitions -->
@@ -317,6 +277,10 @@
 			</xs:sequence>
 			<xs:attribute ref="xml:base"/>
 		</xs:complexType>
+		<xs:key name="scenarioKey">
+			<xs:selector xpath="fixr:scenario"/>
+			<xs:field xpath="@name"/>
+		</xs:key>
 	</xs:element>
 	<!-- Section definitions -->
 	<xs:element name="sections">

--- a/repository/src/main/resources/xsd/repository.xsd
+++ b/repository/src/main/resources/xsd/repository.xsd
@@ -63,10 +63,6 @@
 						<xs:selector xpath="fixr:code"/>
 						<xs:field xpath="@name"/>
 					</xs:key>
-					<xs:key name="codeIdKey">
-						<xs:selector xpath="fixr:code"/>
-						<xs:field xpath="@id"/>
-					</xs:key>
 				</xs:element>
 				<xs:element ref="fixr:encodings" minOccurs="0"/>
 				<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
@@ -249,21 +245,41 @@
 			</xs:attribute>
 		</xs:complexType>
 		<!-- Type attribute of a code set definition must reference a valid datatype name -->
-		<xs:keyref name="codeSetTypeRef" refer="fixr:datatypeKey">
+		<xs:keyref name="codeSetTypeKeyRef" refer="fixr:datatypeKey">
 			<xs:selector xpath="fixr:codeSets/fixr:codeSet"/>
 			<xs:field xpath="@type"/>
 		</xs:keyref>
 		<!-- Type attribute of a field definition must reference a valid datatype name -->
-		<xs:keyref name="fieldTypeRef" refer="fixr:datatypeKey">
+		<xs:keyref name="fieldTypeKeyRef" refer="fixr:datatypeKey">
 			<xs:selector xpath="fixr:fields/fixr:field"/>
 			<xs:field xpath="@type"/>
 		</xs:keyref>
 		<!-- Code set and scenario attributes in a field definition must reference a valid code set name and scenario -->
-		<xs:keyref name="fieldCodeSetRef" refer="fixr:codeSetNameKey">
+		<xs:keyref name="fieldCodeSetKeyRef" refer="fixr:codeSetNameKey">
 			<xs:selector xpath="fixr:fields/fixr:field"/>
 			<xs:field xpath="@codeSet"/>
 			<xs:field xpath="@scenario"/>
 		</xs:keyref>
+        <!-- A scenario used in a code set definition must be a valid scenario defined in the list of scenarios -->
+        <xs:keyref name="codeSetScenarioKeyRef" refer="fixr:scenarioKey">
+            <xs:selector xpath="fixr:codeSets/fixr:codeSet"/>
+            <xs:field xpath="@scenario"/>
+        </xs:keyref>
+        <!-- A scenario used in a component definition must be a valid scenario defined in the list of scenarios -->
+        <xs:keyref name="componentScenarioKeyRef" refer="fixr:scenarioKey">
+            <xs:selector xpath="fixr:components/fixr:component"/>
+            <xs:field xpath="@scenario"/>
+        </xs:keyref>
+        <!-- A scenario used in a group definition must be a valid scenario defined in the list of scenarios -->
+        <xs:keyref name="groupScenarioKeyRef" refer="fixr:scenarioKey">
+            <xs:selector xpath="fixr:groups/fixr:group"/>
+            <xs:field xpath="@scenario"/>
+        </xs:keyref>
+        <!-- A scenario used in a message definition must be a valid scenario defined in the list of scenarios -->
+        <xs:keyref name="messageScenarioKeyRef" refer="fixr:scenarioKey">
+            <xs:selector xpath="fixr:messages/fixr:message"/>
+            <xs:field xpath="@scenario"/>
+        </xs:keyref>
 	</xs:element>
 	<!-- Scenario definitions -->
 	<xs:element name="scenarios">

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -723,11 +723,6 @@
 				<xs:documentation>The use case of an element, distinguished by workflow, asset class, etc.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="scenarioId" type="fixr:id_t" default="1">
-			<xs:annotation>
-				<xs:documentation>Unique identifier of a scenario. Default is '1' for base scenario.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
 	</xs:attributeGroup>
 	<xs:simpleType name="presence_t">
 		<xs:restriction base="xs:string">
@@ -832,11 +827,6 @@
 				<xs:documentation>The use case of an element, distinguished by workflow, asset class, etc.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="scenarioId" type="fixr:id_t" default="1">
-			<xs:annotation>
-				<xs:documentation>Unique identifier of a scenario. Default is '1' for base scenario.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="scenarioRefGrp">
 		<xs:annotation>
@@ -892,11 +882,6 @@
 		<xs:sequence>
 			<xs:element name="annotation" type="fixr:annotation" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute name="id" type="fixr:id_t" default="1">
-			<xs:annotation>
-				<xs:documentation>Unique numeric identifier. Default is '1' is for base scenario.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
 		<xs:attribute name="name" type="fixr:Name_t" default="base">
 			<xs:annotation>
 				<xs:documentation>Unique name</xs:documentation>


### PR DESCRIPTION
Also, clean up and fix invalid keyrefs.

Fixes #271

I found that several of the keyref declarations were not actually valid, because instead of using selector e.g. `fixr:codeSets/fixr:codeSet` they just used `fix:codeSet`, which would not match anything. I believe I have them working as intended now.

One thing, however, was that I've tentatively removed the check that a scenario attribute refers to a scenario defined at the top level.
- if we had that requirement, then 100% of the time, users would have to include an arguably superfluous `<fixr:scenarios><fixr:scenario name="base"/></fixr:secnarios>`, even if they do not otherwise use scenarios
- I would personally like to recommend that we don't require scenarios to be defined at the top level, allowing their implicit usage like we have today, while still enabling users to define them at the top level if they wish (to include documentation, for example)