### PR TITLE
Add length and range attributes to code sets

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '11'

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<module>repository-util</module>
 		<module>orchestra-common</module>
 		<module>interfaces-util</module>
-		<module>orchestra2doc</module>
+		<!-- <module>orchestra2doc</module> -->
 	</modules>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -136,10 +136,10 @@
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attributeGroup ref="fixr:fieldAttribGrp">
-		<xs:annotation>
-			<xs:documentation>Length and range information for values in the code set</xs:documentation>
-		</xs:annotation>
-	</xs:attribute>
+			<xs:annotation>
+				<xs:documentation>Length and range information for values in the code set</xs:documentation>
+			</xs:annotation>
+		</xs:attributeGroup>
 		<xs:attributeGroup ref="fixr:entityAttribGrp"/>
 		<xs:attribute name="unionDataType" type="fixr:Name_t"/>
 	</xs:complexType>

--- a/repository/src/main/resources/xsd/repositorytypes.xsd
+++ b/repository/src/main/resources/xsd/repositorytypes.xsd
@@ -135,6 +135,11 @@
 				<xs:documentation>Reference documentation for an external code set</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attributeGroup ref="fixr:fieldAttribGrp">
+		<xs:annotation>
+			<xs:documentation>Length and range information for values in the code set</xs:documentation>
+		</xs:annotation>
+	</xs:attribute>
 		<xs:attributeGroup ref="fixr:entityAttribGrp"/>
 		<xs:attribute name="unionDataType" type="fixr:Name_t"/>
 	</xs:complexType>
@@ -300,7 +305,6 @@
 		</xs:attribute>
 		<xs:attribute name="implMinLength" type="xs:short"/>
 		<xs:attribute name="implMaxLength" type="xs:short"/>
-		<xs:attribute name="presence" type="fixr:presence_t" default="optional"/>
 		<xs:attribute name="encoding" type="xs:string">
 			<xs:annotation>
 				<xs:documentation>Character encoding if other than US-ASCII
@@ -355,6 +359,7 @@
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attributeGroup ref="fixr:fieldAttribGrp"/>
+		<xs:attribute name="presence" type="fixr:presence_t" default="optional"/>
 		<xs:attribute name="instanceName" type="fixr:Name_t">
 			<xs:annotation>
 				<xs:documentation>Override the field name for this instance, for


### PR DESCRIPTION
Move presence attribute out of field attributes and only use it for field references, not for field references or field rules (has no meaning there).